### PR TITLE
Fix placement cache race with per-API generations

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -38,7 +38,6 @@ type CollectCacheOptions struct {
 	DnsConcurrentCount          int
 	UUIDGenFunc                 func() (string, error)
 	CompletePlacementInParallel bool
-	CollectPlacementTraits      bool
 }
 
 func CollectCache(options CollectCacheOptions, logger *slog.Logger) error {
@@ -88,7 +87,6 @@ func CollectCache(options CollectCacheOptions, logger *slog.Logger) error {
 				DnsConcurrentCount:          options.DnsConcurrentCount,
 				UUIDGenFunc:                 options.UUIDGenFunc,
 				CompletePlacementInParallel: options.CompletePlacementInParallel,
-				CollectPlacementTraits:      options.CollectPlacementTraits,
 			}, logger)
 			if err != nil {
 				// Log error and continue with enabling other exporters

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -67,7 +67,6 @@ type ExporterOptions struct {
 	DnsConcurrentCount          int
 	UUIDGenFunc                 func() (string, error)
 	CompletePlacementInParallel bool
-	CollectPlacementTraits      bool
 }
 
 func EnableExporter(options ExporterOptions, logger *slog.Logger) (*OpenStackExporter, error) {
@@ -98,7 +97,6 @@ type ExporterConfig struct {
 	NovaMetadataMapping         *utils.LabelMappingFlag
 	DnsConcurrentCount          int
 	CompletePlacementInParallel bool
-	CollectPlacementTraits      bool
 }
 
 type BaseOpenStackExporter struct {
@@ -362,7 +360,6 @@ func NewExporter(options ExporterOptions, logger *slog.Logger) (OpenStackExporte
 		NovaMetadataMapping:         options.NovaMetadataMapping,
 		DnsConcurrentCount:          options.DnsConcurrentCount,
 		CompletePlacementInParallel: options.CompletePlacementInParallel,
-		CollectPlacementTraits:      options.CollectPlacementTraits,
 	}
 
 	switch options.Service {

--- a/exporters/exporter_test.go
+++ b/exporters/exporter_test.go
@@ -141,6 +141,8 @@ var fixtures map[string]string = map[string]string{
 	"/orchestration/stacks":         "heat_stacks",
 	"/placement/":                   "placement_api_discovery",
 	"/placement/resource_providers": "resource_providers",
+	"/placement/resource_providers/b985be15-99bf-4baf-9ef7-3ef166cd7f31/traits": "resource_provider_1_traits",
+	"/placement/resource_providers/328c9f0a-5a3c-4ad6-9347-689eb7632d7b/traits": "resource_provider_2_traits",
 	"/placement/resource_providers/b985be15-99bf-4baf-9ef7-3ef166cd7f31/inventories": "resource_provider_1_inventory",
 	"/placement/resource_providers/328c9f0a-5a3c-4ad6-9347-689eb7632d7b/inventories": "resource_provider_2_inventory",
 	"/placement/resource_providers/b985be15-99bf-4baf-9ef7-3ef166cd7f31/usages":      "resource_provider_1_usage",

--- a/exporters/fixtures/resource_provider_1_traits.json
+++ b/exporters/fixtures/resource_provider_1_traits.json
@@ -1,0 +1,1 @@
+{"resource_provider_generation": 20, "traits": []}

--- a/exporters/fixtures/resource_provider_2_traits.json
+++ b/exporters/fixtures/resource_provider_2_traits.json
@@ -1,0 +1,1 @@
+{"resource_provider_generation": 12, "traits": []}

--- a/exporters/placement.go
+++ b/exporters/placement.go
@@ -6,8 +6,10 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/placement/v1/resourceproviders"
+	"github.com/openstack-exporter/openstack-exporter/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -18,8 +20,34 @@ type cachedMetricEntry struct {
 }
 
 type cachedProviderData struct {
-	generation int
-	metrics    []cachedMetricEntry
+	listGeneration       int
+	traitsGeneration     int
+	inventoryGeneration  int
+	usageGeneration      int
+	allocationGeneration int
+	traitsMetrics        []cachedMetricEntry
+	inventoryMetrics     []cachedMetricEntry
+	usageMetrics         []cachedMetricEntry
+	allocationMetrics    []cachedMetricEntry
+}
+
+func (c *cachedProviderData) allMetrics() []cachedMetricEntry {
+	var all []cachedMetricEntry
+	all = append(all, c.traitsMetrics...)
+	all = append(all, c.inventoryMetrics...)
+	all = append(all, c.usageMetrics...)
+	all = append(all, c.allocationMetrics...)
+	return all
+}
+
+// staleAPIs returns which API calls need re-fetching because their
+// generation doesn't match the list generation.
+func (c *cachedProviderData) staleAPIs(listGen int) (traits, inventory, usage, allocations bool) {
+	traits = c.traitsGeneration != listGen
+	inventory = c.inventoryGeneration != listGen
+	usage = c.usageGeneration != listGen
+	allocations = c.allocationGeneration != listGen
+	return
 }
 
 type placementCache struct {
@@ -32,18 +60,14 @@ var globalPlacementCaches = struct {
 	caches map[string]*placementCache
 }{caches: make(map[string]*placementCache)}
 
-func getPlacementCache(endpoint string, collectTraits bool) *placementCache {
+func getPlacementCache(endpoint string) *placementCache {
 	globalPlacementCaches.mu.Lock()
 	defer globalPlacementCaches.mu.Unlock()
-	cacheKey := endpoint
-	if collectTraits {
-		cacheKey += "|traits"
-	}
-	if c, ok := globalPlacementCaches.caches[cacheKey]; ok {
+	if c, ok := globalPlacementCaches.caches[endpoint]; ok {
 		return c
 	}
 	c := &placementCache{providers: make(map[string]*cachedProviderData)}
-	globalPlacementCaches.caches[cacheKey] = c
+	globalPlacementCaches.caches[endpoint] = c
 	return c
 }
 
@@ -66,14 +90,23 @@ var defaultPlacementMetrics = []Metric{
 	{Name: "resource_provider_allocations", Labels: placementAllocationLabels},
 }
 
+const placementLatestSupportedMicroversion = "1.39"
+
 func NewPlacementExporter(config *ExporterConfig, logger *slog.Logger) (*PlacementExporter, error) {
+	ctx := context.TODO()
+
+	err := utils.SetupClientMicroversionV2(ctx, config.ClientV2, "OS_PLACEMENT_API_VERSION", placementLatestSupportedMicroversion, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	exporter := &PlacementExporter{
 		BaseOpenStackExporter: BaseOpenStackExporter{
 			Name:           "placement",
 			ExporterConfig: *config,
 			logger:         logger,
 		},
-		cache: getPlacementCache(config.ClientV2.Endpoint, config.CollectPlacementTraits),
+		cache: getPlacementCache(config.ClientV2.Endpoint),
 	}
 
 	for _, metric := range defaultPlacementMetrics {
@@ -92,6 +125,7 @@ func NewPlacementExporter(config *ExporterConfig, logger *slog.Logger) (*Placeme
 }
 
 const maxConcurrentPlacementRequests = 50
+const maxStaleRetries = 3
 
 func (pe *PlacementExporter) listWithCache(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	allPagesResourceProviders, err := resourceproviders.List(exporter.ClientV2, resourceproviders.ListOpts{}).AllPages(ctx)
@@ -105,17 +139,42 @@ func (pe *PlacementExporter) listWithCache(ctx context.Context, exporter *BaseOp
 	}
 
 	currentProviderUUIDs := make(map[string]struct{}, len(allResourceProviders))
-	var providersToFetch []resourceproviders.ResourceProvider
+
+	var providersToFetch []fetchRequest
+	var fullFetchCount, partialFetchCount int
 
 	pe.cache.mu.Lock()
 	for _, rp := range allResourceProviders {
 		currentProviderUUIDs[rp.UUID] = struct{}{}
 
 		cached, exists := pe.cache.providers[rp.UUID]
-		if exists && cached.generation == rp.Generation {
-			emitCachedMetrics(exporter, ch, cached)
+		if !exists || cached.listGeneration != rp.Generation {
+			// Full re-fetch: new provider or generation changed
+			providersToFetch = append(providersToFetch, fetchRequest{
+				rp: rp, refetchTraits: true, refetchInventory: true,
+				refetchUsage: true, refetchAllocations: true,
+			})
+			fullFetchCount++
 		} else {
-			providersToFetch = append(providersToFetch, rp)
+			// Generation matches list - check per-API staleness
+			staleTraits, staleInv, staleUsage, staleAlloc := cached.staleAPIs(rp.Generation)
+			if staleTraits || staleInv {
+				// Traits/inventory are embedded in all labels - must do full refetch
+				providersToFetch = append(providersToFetch, fetchRequest{
+					rp: rp, refetchTraits: true, refetchInventory: true,
+					refetchUsage: true, refetchAllocations: true,
+				})
+				fullFetchCount++
+			} else if staleUsage || staleAlloc {
+				providersToFetch = append(providersToFetch, fetchRequest{
+					rp: rp, refetchTraits: false, refetchInventory: false,
+					refetchUsage: staleUsage, refetchAllocations: staleAlloc,
+				})
+				partialFetchCount++
+			} else {
+				// All generations match - serve from cache
+				emitCachedMetrics(exporter, ch, cached)
+			}
 		}
 	}
 
@@ -129,21 +188,22 @@ func (pe *PlacementExporter) listWithCache(ctx context.Context, exporter *BaseOp
 	exporter.logger.Info("Placement cache status",
 		"total_providers", len(allResourceProviders),
 		"cache_hits", len(allResourceProviders)-len(providersToFetch),
-		"providers_to_fetch", len(providersToFetch),
+		"full_fetches", fullFetchCount,
+		"partial_fetches", partialFetchCount,
 	)
 
-	if len(providersToFetch) == 0 {
-		return nil
+	if len(providersToFetch) > 0 {
+		concurrency := 1
+		if exporter.CompletePlacementInParallel {
+			concurrency = maxConcurrentPlacementRequests
+		}
+		err = fetchAndCachePlacementProviders(ctx, exporter, ch, providersToFetch, concurrency, pe.cache)
 	}
 
-	concurrency := 1
-	if exporter.CompletePlacementInParallel {
-		concurrency = maxConcurrentPlacementRequests
-	}
-	return collectAndCachePlacementProviders(ctx, exporter, ch, providersToFetch, concurrency, pe.cache)
+	return err
 }
 
-// ListPlacementResourceProviders is the non-cached version used by tests and as fallback.
+// ListPlacementResourceProviders is the non-cached version used by tests and as fallback
 func ListPlacementResourceProviders(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric) error {
 	var allResourceProviders []resourceproviders.ResourceProvider
 
@@ -160,10 +220,26 @@ func ListPlacementResourceProviders(ctx context.Context, exporter *BaseOpenStack
 	if exporter.CompletePlacementInParallel {
 		concurrency = maxConcurrentPlacementRequests
 	}
-	return collectAndCachePlacementProviders(ctx, exporter, ch, allResourceProviders, concurrency, nil)
+
+	requests := make([]fetchRequest, len(allResourceProviders))
+	for i, rp := range allResourceProviders {
+		requests[i] = fetchRequest{
+			rp: rp, refetchTraits: true, refetchInventory: true,
+			refetchUsage: true, refetchAllocations: true,
+		}
+	}
+	return fetchAndCachePlacementProviders(ctx, exporter, ch, requests, concurrency, nil)
 }
 
-func collectAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric, providers []resourceproviders.ResourceProvider, concurrency int, cache *placementCache) error {
+type fetchRequest struct {
+	rp                 resourceproviders.ResourceProvider
+	refetchTraits      bool
+	refetchInventory   bool
+	refetchUsage       bool
+	refetchAllocations bool
+}
+
+func fetchAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric, requests []fetchRequest, concurrency int, cache *placementCache) error {
 	semaphore := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 	var errMu sync.Mutex
@@ -177,8 +253,8 @@ func collectAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenSt
 		}
 	}
 
-	for _, resourceprovider := range providers {
-		resourceprovider := resourceprovider
+	for _, req := range requests {
+		req := req
 
 		wg.Add(1)
 		go func() {
@@ -186,11 +262,41 @@ func collectAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenSt
 			semaphore <- struct{}{}
 			defer func() { <-semaphore }()
 
-			var entries []cachedMetricEntry
+			rp := req.rp
+			listGen := rp.Generation
 
+			// Get existing cache entry if doing partial re-fetch.
+			// Deep copy slices to avoid aliasing with concurrent scrapes.
+			var existing *cachedProviderData
+			if cache != nil {
+				cache.mu.Lock()
+				if e, ok := cache.providers[rp.UUID]; ok {
+					existing = &cachedProviderData{
+						listGeneration:       e.listGeneration,
+						traitsGeneration:     e.traitsGeneration,
+						inventoryGeneration:  e.inventoryGeneration,
+						usageGeneration:      e.usageGeneration,
+						allocationGeneration: e.allocationGeneration,
+						traitsMetrics:        append([]cachedMetricEntry(nil), e.traitsMetrics...),
+						inventoryMetrics:     append([]cachedMetricEntry(nil), e.inventoryMetrics...),
+						usageMetrics:         append([]cachedMetricEntry(nil), e.usageMetrics...),
+						allocationMetrics:    append([]cachedMetricEntry(nil), e.allocationMetrics...),
+					}
+				}
+				cache.mu.Unlock()
+			}
+
+			var traitsMetrics []cachedMetricEntry
+			var inventoryMetrics []cachedMetricEntry
+			var usageMetrics []cachedMetricEntry
+			var allocationMetrics []cachedMetricEntry
+			var traitsGen, invGen, usageGen, allocGen int
+
+			// Traits
 			traitsStr := ""
-			if exporter.CollectPlacementTraits {
-				if traitResult, err := resourceproviders.GetTraits(ctx, exporter.ClientV2, resourceprovider.UUID).Extract(); err == nil {
+			if req.refetchTraits {
+				if traitResult, err := resourceproviders.GetTraits(ctx, exporter.ClientV2, rp.UUID).Extract(); err == nil {
+					traitsGen = traitResult.ResourceProviderGeneration
 					traits := make([]string, 0, len(traitResult.Traits))
 					for _, trait := range traitResult.Traits {
 						if strings.HasPrefix(trait, "CUSTOM_") {
@@ -200,64 +306,132 @@ func collectAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenSt
 					sort.Strings(traits)
 					traitsStr = strings.Join(traits, ",")
 				} else {
-					exporter.logger.Warn("failed to retrieve placement resource provider traits", "resource_provider", resourceprovider.UUID, "error", err)
+					exporter.logger.Warn("failed to retrieve placement resource provider traits", "resource_provider", rp.UUID, "error", err)
+					traitsGen = 0 // force refetch next scrape
 				}
-			}
-
-			inventoryResult, err := resourceproviders.GetInventories(ctx, exporter.ClientV2, resourceprovider.UUID).Extract()
-			if err != nil {
-				setError(err)
-				return
-			}
-
-			for k, v := range inventoryResult.Inventories {
-				entries = append(entries,
-					cachedMetricEntry{"resource_total", float64(v.Total), []string{resourceprovider.Name, k, traitsStr}},
-					cachedMetricEntry{"resource_allocation_ratio", float64(v.AllocationRatio), []string{resourceprovider.Name, k, traitsStr}},
-					cachedMetricEntry{"resource_generation", float64(inventoryResult.ResourceProviderGeneration), []string{resourceprovider.Name, k, traitsStr}},
-					cachedMetricEntry{"resource_reserved", float64(v.Reserved), []string{resourceprovider.Name, k, traitsStr}},
-				)
-			}
-
-			usagesResult, err := resourceproviders.GetUsages(ctx, exporter.ClientV2, resourceprovider.UUID).Extract()
-			if err != nil {
-				setError(err)
-				return
-			}
-
-			for k, v := range usagesResult.Usages {
-				entries = append(entries,
-					cachedMetricEntry{"resource_usage", float64(v), []string{resourceprovider.Name, k, traitsStr}},
-				)
-			}
-
-			entries = append(entries,
-				cachedMetricEntry{"resource_traits", 1.0, []string{resourceprovider.Name, traitsStr}},
-			)
-
-			if _, ok := exporter.Metrics["resource_provider_allocations"]; ok {
-				allocationsResult, err := resourceproviders.GetAllocations(ctx, exporter.ClientV2, resourceprovider.UUID).Extract()
-				if err != nil {
-					setError(err)
-					return
-				}
-
-				for consumerID, allocation := range allocationsResult.Allocations {
-					for resourceClass, amount := range allocation.Resources {
-						entries = append(entries,
-							cachedMetricEntry{"resource_provider_allocations", float64(amount), []string{resourceprovider.Name, consumerID, resourceClass}},
-						)
+				traitsMetrics = append(traitsMetrics, cachedMetricEntry{"resource_traits", 1.0, []string{rp.Name, traitsStr}})
+			} else if existing != nil {
+				traitsMetrics = existing.traitsMetrics
+				traitsGen = existing.traitsGeneration
+				// Extract traitsStr from cached metrics for use in other fetches
+				for _, m := range existing.traitsMetrics {
+					if m.metricName == "resource_traits" && len(m.labels) >= 2 {
+						traitsStr = m.labels[1]
 					}
 				}
 			}
 
-			emitCachedMetrics(exporter, ch, &cachedProviderData{metrics: entries})
+			// Inventories
+			if req.refetchInventory {
+				inventoryResult, err := resourceproviders.GetInventories(ctx, exporter.ClientV2, rp.UUID).Extract()
+				if err != nil {
+					setError(err)
+					return
+				}
+				invGen = inventoryResult.ResourceProviderGeneration
+				for k, v := range inventoryResult.Inventories {
+					inventoryMetrics = append(inventoryMetrics,
+						cachedMetricEntry{"resource_total", float64(v.Total), []string{rp.Name, k, traitsStr}},
+						cachedMetricEntry{"resource_allocation_ratio", float64(v.AllocationRatio), []string{rp.Name, k, traitsStr}},
+						cachedMetricEntry{"resource_generation", float64(inventoryResult.ResourceProviderGeneration), []string{rp.Name, k, traitsStr}},
+						cachedMetricEntry{"resource_reserved", float64(v.Reserved), []string{rp.Name, k, traitsStr}},
+					)
+				}
+			} else if existing != nil {
+				inventoryMetrics = existing.inventoryMetrics
+				invGen = existing.inventoryGeneration
+			}
 
+			// Usages - retry if generation is stale
+			if req.refetchUsage {
+				for attempt := 0; attempt < maxStaleRetries; attempt++ {
+					usagesResult, err := resourceproviders.GetUsages(ctx, exporter.ClientV2, rp.UUID).Extract()
+					if err != nil {
+						setError(err)
+						return
+					}
+					usageGen = usagesResult.ResourceProviderGeneration
+					usageMetrics = nil
+					for k, v := range usagesResult.Usages {
+						usageMetrics = append(usageMetrics,
+							cachedMetricEntry{"resource_usage", float64(v), []string{rp.Name, k, traitsStr}},
+						)
+					}
+					if usageGen >= listGen {
+						break
+					}
+					exporter.logger.Warn("Placement usage generation stale, retrying",
+						"resource_provider", rp.Name,
+						"list_generation", listGen,
+						"usage_generation", usageGen,
+						"attempt", attempt+1,
+					)
+					time.Sleep(100 * time.Millisecond)
+				}
+			} else if existing != nil {
+				usageMetrics = existing.usageMetrics
+				usageGen = existing.usageGeneration
+			}
+
+			// Allocations - retry if generation is stale
+			if req.refetchAllocations {
+				if _, ok := exporter.Metrics["resource_provider_allocations"]; ok {
+					for attempt := 0; attempt < maxStaleRetries; attempt++ {
+						allocationsResult, err := resourceproviders.GetAllocations(ctx, exporter.ClientV2, rp.UUID).Extract()
+						if err != nil {
+							setError(err)
+							return
+						}
+						allocGen = allocationsResult.ResourceProviderGeneration
+						allocationMetrics = nil
+						for consumerID, allocation := range allocationsResult.Allocations {
+							for resourceClass, amount := range allocation.Resources {
+								allocationMetrics = append(allocationMetrics,
+									cachedMetricEntry{"resource_provider_allocations", float64(amount), []string{rp.Name, consumerID, resourceClass}},
+								)
+							}
+						}
+						if allocGen >= listGen {
+							break
+						}
+						exporter.logger.Warn("Placement allocations generation stale, retrying",
+							"resource_provider", rp.Name,
+							"list_generation", listGen,
+							"allocations_generation", allocGen,
+							"attempt", attempt+1,
+						)
+						time.Sleep(100 * time.Millisecond)
+					}
+				} else {
+					allocGen = listGen
+				}
+			} else if existing != nil {
+				allocationMetrics = existing.allocationMetrics
+				allocGen = existing.allocationGeneration
+			}
+
+			// Build the cache entry
+			entry := &cachedProviderData{
+				listGeneration:       listGen,
+				traitsGeneration:     traitsGen,
+				inventoryGeneration:  invGen,
+				usageGeneration:      usageGen,
+				allocationGeneration: allocGen,
+				traitsMetrics:        traitsMetrics,
+				inventoryMetrics:     inventoryMetrics,
+				usageMetrics:         usageMetrics,
+				allocationMetrics:    allocationMetrics,
+			}
+
+			// Emit metrics
+			emitCachedMetrics(exporter, ch, entry)
+
+			// Store in cache - only if our data is at least as fresh as
+			// what's currently stored (avoids TOCTOU with overlapping scrapes)
 			if cache != nil {
 				cache.mu.Lock()
-				cache.providers[resourceprovider.UUID] = &cachedProviderData{
-					generation: resourceprovider.Generation,
-					metrics:    entries,
+				if existing, ok := cache.providers[rp.UUID]; !ok || existing.listGeneration <= listGen {
+					cache.providers[rp.UUID] = entry
 				}
 				cache.mu.Unlock()
 			}
@@ -269,7 +443,7 @@ func collectAndCachePlacementProviders(ctx context.Context, exporter *BaseOpenSt
 }
 
 func emitCachedMetrics(exporter *BaseOpenStackExporter, ch chan<- prometheus.Metric, data *cachedProviderData) {
-	for _, entry := range data.metrics {
+	for _, entry := range data.allMetrics() {
 		if desc, ok := exporter.Metrics[entry.metricName]; ok {
 			ch <- prometheus.MustNewConstMetric(
 				desc.Metric,

--- a/exporters/placement_benchmark_test.go
+++ b/exporters/placement_benchmark_test.go
@@ -184,7 +184,6 @@ func newPlacementBenchmarkFixture(b *testing.B, parallel bool) *placementBenchma
 		DisabledMetrics: []string{},
 	}
 	setPlacementBenchmarkBoolField(config, "CompletePlacementInParallel", parallel)
-	setPlacementBenchmarkBoolField(config, "CollectPlacementTraits", false)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	exporter, err := exporters.NewPlacementExporter(config, logger)

--- a/exporters/placement_cache_test.go
+++ b/exporters/placement_cache_test.go
@@ -1,0 +1,88 @@
+package exporters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlacementCacheStaleAPIs(t *testing.T) {
+	// Test that staleAPIs correctly identifies mismatched generations
+	data := &cachedProviderData{
+		listGeneration:       10,
+		traitsGeneration:     10,
+		inventoryGeneration:  10,
+		usageGeneration:      8, // stale
+		allocationGeneration: 10,
+	}
+
+	traits, inv, usage, alloc := data.staleAPIs(10)
+	assert.False(t, traits, "traits should not be stale")
+	assert.False(t, inv, "inventory should not be stale")
+	assert.True(t, usage, "usage should be stale (8 != 10)")
+	assert.False(t, alloc, "allocations should not be stale")
+}
+
+func TestPlacementCacheAllFresh(t *testing.T) {
+	data := &cachedProviderData{
+		listGeneration:       10,
+		traitsGeneration:     10,
+		inventoryGeneration:  10,
+		usageGeneration:      10,
+		allocationGeneration: 10,
+	}
+
+	traits, inv, usage, alloc := data.staleAPIs(10)
+	assert.False(t, traits)
+	assert.False(t, inv)
+	assert.False(t, usage)
+	assert.False(t, alloc)
+}
+
+func TestPlacementCacheTraitsStaleTriggersFullRefetch(t *testing.T) {
+	// When traits are stale, we should NOT do a partial refetch
+	// (the calling code promotes to full refetch)
+	data := &cachedProviderData{
+		listGeneration:       10,
+		traitsGeneration:     9, // stale
+		inventoryGeneration:  10,
+		usageGeneration:      10,
+		allocationGeneration: 10,
+	}
+
+	traits, inv, _, _ := data.staleAPIs(10)
+	assert.True(t, traits, "traits stale should be detected")
+	assert.False(t, inv, "inventory is fresh")
+	// In the calling code, stale traits triggers full refetch
+}
+
+func TestPlacementCacheTraitsErrorSetsZeroGeneration(t *testing.T) {
+	// When traits fetch fails, generation should be 0 (not listGen)
+	// so it's detected as stale on next scrape
+	data := &cachedProviderData{
+		listGeneration:       10,
+		traitsGeneration:     0, // failed fetch
+		inventoryGeneration:  10,
+		usageGeneration:      10,
+		allocationGeneration: 10,
+	}
+
+	traits, _, _, _ := data.staleAPIs(10)
+	assert.True(t, traits, "zero generation (failed traits) should be detected as stale")
+}
+
+func TestPlacementCacheAllMetrics(t *testing.T) {
+	data := &cachedProviderData{
+		traitsMetrics:     []cachedMetricEntry{{"resource_traits", 1.0, []string{"host", "CUSTOM_A"}}},
+		inventoryMetrics:  []cachedMetricEntry{{"resource_total", 96, []string{"host", "VCPU", "CUSTOM_A"}}},
+		usageMetrics:      []cachedMetricEntry{{"resource_usage", 10, []string{"host", "VCPU", "CUSTOM_A"}}},
+		allocationMetrics: []cachedMetricEntry{{"resource_provider_allocations", 4, []string{"host", "uuid1", "VCPU"}}},
+	}
+
+	all := data.allMetrics()
+	assert.Equal(t, 4, len(all))
+	assert.Equal(t, "resource_traits", all[0].metricName)
+	assert.Equal(t, "resource_total", all[1].metricName)
+	assert.Equal(t, "resource_usage", all[2].metricName)
+	assert.Equal(t, "resource_provider_allocations", all[3].metricName)
+}

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ var (
 	disableServiceAutodetect    = kingpin.Flag("disable-service-autodetect", "Disable single-cloud service autodetection and use only explicit service flags").Default("false").Bool()
 	novaMetadataMapping         = utils.LabelMapping(kingpin.Flag("nova.metadata-extra-labels", "Map provided server metadata keys to labels in openstack_nova_server_status metric").PlaceHolder("LABEL=KEY,KEY").Default(""))
 	completePlacementInParallel = kingpin.Flag("complete-placement-in-parallel", "Enable parallel collection of placement resource provider data").Default("false").Bool()
-	collectPlacementTraits      = kingpin.Flag("collect-placement-traits", "Collect custom traits for placement resource provider metrics").Default("false").Bool()
 	dnsConcurrentCount          = kingpin.Flag("dns-concurrent-count", "Number of concurrent requests for DNS recordset collection").Default("10").Int()
 )
 
@@ -263,7 +262,6 @@ func cacheOptions(services []string) cache.CollectCacheOptions {
 		NovaMetadataMapping:         novaMetadataMapping,
 		DnsConcurrentCount:          *dnsConcurrentCount,
 		CompletePlacementInParallel: *completePlacementInParallel,
-		CollectPlacementTraits:      *collectPlacementTraits,
 	}
 }
 
@@ -283,7 +281,6 @@ func exporterOptions(service, cloud string) exporters.ExporterOptions {
 		NovaMetadataMapping:         novaMetadataMapping,
 		DnsConcurrentCount:          *dnsConcurrentCount,
 		CompletePlacementInParallel: *completePlacementInParallel,
-		CollectPlacementTraits:      *collectPlacementTraits,
 	}
 }
 


### PR DESCRIPTION
Track each Placement provider API generation separately so stale usage and allocation responses are retried instead of being served indefinitely.

Waiting on Nova review: https://review.opendev.org/c/openstack/nova/+/1003208

This PR is intentionally draft until the Nova review lands.