### PR TITLE
Add metrics from issue #603

### DIFF
--- a/exporters/cinder.go
+++ b/exporters/cinder.go
@@ -48,9 +48,10 @@ func mapVolumeStatus(volStatus string) int {
 var defaultCinderMetrics = []Metric{
 	{Name: "volumes", Fn: ListVolumes},
 	{Name: "snapshots", Fn: ListSnapshots},
+	{Name: "snapshots_by_tenant", Labels: []string{"tenant_id"}},
 	{Name: "agent_state", Labels: []string{"uuid", "hostname", "service", "adminState", "zone", "disabledReason"}, Fn: ListCinderAgentState},
 	{Name: "volume_gb", Labels: []string{"id", "name", "status", "availability_zone", "bootable", "tenant_id", "user_id", "volume_type", "server_id"}, Fn: nil},
-	{Name: "volume_status", Labels: []string{"id", "name", "status", "bootable", "tenant_id", "size", "volume_type", "server_id"}, Fn: ListVolumesStatus, Slow: false, DeprecatedVersion: "1.4"},
+	{Name: "volume_status", Labels: []string{"id", "name", "status", "bootable", "tenant_id", "size", "volume_type", "server_id", "host"}, Fn: ListVolumesStatus, Slow: false, DeprecatedVersion: "1.4"},
 	{Name: "volume_status_counter", Labels: []string{"status"}, Fn: nil},
 	{Name: "pool_capacity_free_gb", Labels: []string{"name", "volume_backend_name", "vendor_name"}, Fn: ListCinderPoolCapacityFree},
 	{Name: "pool_capacity_total_gb", Labels: []string{"name", "volume_backend_name", "vendor_name"}, Fn: nil},
@@ -107,7 +108,7 @@ func ListVolumesStatus(ctx context.Context, exporter *BaseOpenStackExporter, ch 
 
 		ch <- prometheus.MustNewConstMetric(exporter.Metrics["volume_status"].Metric,
 			prometheus.GaugeValue, float64(mapVolumeStatus(volume.Status)), volume.ID, volume.Name,
-			volume.Status, volume.Bootable, volume.TenantID, strconv.Itoa(volume.Size), volume.VolumeType, serverID)
+			volume.Status, volume.Bootable, volume.TenantID, strconv.Itoa(volume.Size), volume.VolumeType, serverID, volume.Host)
 	}
 
 	return nil
@@ -180,6 +181,17 @@ func ListSnapshots(ctx context.Context, exporter *BaseOpenStackExporter, ch chan
 
 	ch <- prometheus.MustNewConstMetric(exporter.Metrics["snapshots"].Metric,
 		prometheus.GaugeValue, float64(len(allSnapshots)))
+
+	if !exporter.MetricIsDisabled("snapshots_by_tenant") {
+		counts := make(map[string]int)
+		for _, snapshot := range allSnapshots {
+			counts[snapshot.ProjectID]++
+		}
+		for tenantID, count := range counts {
+			ch <- prometheus.MustNewConstMetric(exporter.Metrics["snapshots_by_tenant"].Metric,
+				prometheus.GaugeValue, float64(count), tenantID)
+		}
+	}
 
 	return nil
 }

--- a/exporters/cinder_test.go
+++ b/exporters/cinder_test.go
@@ -66,6 +66,9 @@ openstack_cinder_pool_capacity_total_gb{name="i666testhost@FastPool01",vendor_na
 # HELP openstack_cinder_snapshots snapshots
 # TYPE openstack_cinder_snapshots gauge
 openstack_cinder_snapshots 1
+# HELP openstack_cinder_snapshots_by_tenant snapshots_by_tenant
+# TYPE openstack_cinder_snapshots_by_tenant gauge
+openstack_cinder_snapshots_by_tenant{tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978"} 1
 # HELP openstack_cinder_up up
 # TYPE openstack_cinder_up gauge
 openstack_cinder_up 1
@@ -75,8 +78,8 @@ openstack_cinder_volume_gb{availability_zone="nova",bootable="false",id="6edbc2f
 openstack_cinder_volume_gb{availability_zone="nova",bootable="true",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",server_id="",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",user_id="32779452fcd34ae1a53a797ac8a1e064",volume_type="lvmdriver-1"} 1
 # HELP openstack_cinder_volume_status volume_status
 # TYPE openstack_cinder_volume_status gauge
-openstack_cinder_volume_status{bootable="false",id="6edbc2f4-1507-44f8-ac0d-eed1d2608d38",name="test-volume-attachments",server_id="f4fda93b-06e0-4743-8117-bc8bcecd651b",size="2",status="in-use",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 5
-openstack_cinder_volume_status{bootable="true",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",server_id="",size="1",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 1
+openstack_cinder_volume_status{bootable="false",host="difleming@lvmdriver-1#lvmdriver-1",id="6edbc2f4-1507-44f8-ac0d-eed1d2608d38",name="test-volume-attachments",server_id="f4fda93b-06e0-4743-8117-bc8bcecd651b",size="2",status="in-use",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 5
+openstack_cinder_volume_status{bootable="true",host="difleming@lvmdriver-1#lvmdriver-1",id="173f7b48-c4c1-4e70-9acc-086b39073506",name="test-volume",server_id="",size="1",status="available",tenant_id="bab7d5c60cd041a0a36f7c4b6e1dd978",volume_type="lvmdriver-1"} 1
 # HELP openstack_cinder_volume_status_counter volume_status_counter
 # TYPE openstack_cinder_volume_status_counter gauge
 openstack_cinder_volume_status_counter{status="attaching"} 0

--- a/exporters/keystone.go
+++ b/exporters/keystone.go
@@ -27,6 +27,7 @@ var defaultKeystoneMetrics = []Metric{
 	{Name: "groups", Fn: ListGroups},
 	{Name: "projects", Fn: ListProjects},
 	{Name: "project_info", Labels: []string{"is_domain", "description", "domain_id", "enabled", "id", "name", "parent_id", "tags"}},
+	{Name: "project_enabled", Labels: []string{"id"}},
 	{Name: "regions", Fn: ListRegions},
 }
 
@@ -93,6 +94,16 @@ func ListProjects(ctx context.Context, exporter *BaseOpenStackExporter, ch chan<
 				prometheus.GaugeValue, 1.0, strconv.FormatBool(p.IsDomain),
 				p.Description, p.DomainID, strconv.FormatBool(p.Enabled), p.ID, p.Name,
 				p.ParentID, strings.Join(p.Tags, ","))
+		}
+	}
+	if !exporter.MetricIsDisabled("project_enabled") {
+		for _, p := range allProjects {
+			value := 0.0
+			if p.Enabled {
+				value = 1.0
+			}
+			ch <- prometheus.MustNewConstMetric(exporter.Metrics["project_enabled"].Metric,
+				prometheus.GaugeValue, value, p.ID)
 		}
 	}
 

--- a/exporters/keystone_test.go
+++ b/exporters/keystone_test.go
@@ -31,6 +31,16 @@ openstack_identity_project_info{description="",domain_id="default",enabled="true
 openstack_identity_project_info{description="",domain_id="default",enabled="true",id="5961c443439d4fcebe42643723755e9d",is_domain="false",name="invisible_to_admin",parent_id="",tags=""} 1
 openstack_identity_project_info{description="",domain_id="default",enabled="true",id="fdb8424c4e4f4c0ba32c52e2de3bd80e",is_domain="false",name="alt_demo",parent_id="",tags=""} 1
 openstack_identity_project_info{description="This is a demo project.",domain_id="default",enabled="true",id="0cbd49cbf76d405d9c86562e1d579bd3",is_domain="false",name="demo",parent_id="",tags=""} 1
+# HELP openstack_identity_project_enabled project_enabled
+# TYPE openstack_identity_project_enabled gauge
+openstack_identity_project_enabled{id="0c4e939acacf4376bdcd1129f1a054ad"} 1
+openstack_identity_project_enabled{id="0cbd49cbf76d405d9c86562e1d579bd3"} 1
+openstack_identity_project_enabled{id="2db68fed84324f29bb73130c6c2094fb"} 1
+openstack_identity_project_enabled{id="3d594eb0f04741069dbbb521635b21c7"} 1
+openstack_identity_project_enabled{id="43ebde53fc314b1c9ea2b8c5dc744927"} 1
+openstack_identity_project_enabled{id="4b1eb781a47440acb8af9850103e537f"} 1
+openstack_identity_project_enabled{id="5961c443439d4fcebe42643723755e9d"} 1
+openstack_identity_project_enabled{id="fdb8424c4e4f4c0ba32c52e2de3bd80e"} 1
 # HELP openstack_identity_projects projects
 # TYPE openstack_identity_projects gauge
 openstack_identity_projects 8

--- a/exporters/nova.go
+++ b/exporters/nova.go
@@ -61,7 +61,7 @@ type NovaExporter struct {
 
 var (
 	defaultNovaServerStatusLabels = []string{"id", "status", "name", "tenant_id", "user_id", "address_ipv4",
-		"address_ipv6", "host_id", "hypervisor_hostname", "uuid", "availability_zone", "flavor_id", "instance_libvirt"}
+		"address_ipv6", "host_id", "hypervisor_hostname", "uuid", "availability_zone", "flavor_id", "instance_libvirt", "task_state"}
 
 	defaultNovaHypervisorLabels = []string{"hostname", "availability_zone", "aggregates"}
 	defaultNovaLimitsLabels     = []string{"tenant", "tenant_id"}
@@ -413,7 +413,7 @@ func ListAllServers(ctx context.Context, exporter *BaseOpenStackExporter, ch cha
 			metadataValues := exporter.NovaMetadataMapping.Extract(server.Metadata)
 
 			ch <- prometheus.MustNewConstMetric(exporter.Metrics["server_status"].Metric,
-				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), append(labelValues, metadataValues...)...)
+				prometheus.GaugeValue, float64(mapServerStatus(server.Status)), append(append(labelValues, server.TaskState), metadataValues...)...)
 		}
 	}
 	return nil

--- a/exporters/nova_test.go
+++ b/exporters/nova_test.go
@@ -490,7 +490,7 @@ openstack_nova_server_local_gb{id="6c773231-6532-447d-b651-9e0d1518b31d",name="o
 openstack_nova_server_local_gb{id="f99bb4a3-90ff-46fa-b8ec-2ef6ac1f3b7d",name="openstack-monitoring-2-prod-zone",tenant_id="110f6313d2d346b4aa90eabe4970b62a"} 10
 # HELP openstack_nova_server_status server_status
 # TYPE openstack_nova_server_status gauge
-openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="1",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",hypervisor_hostname="fake-mini",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",instance_libvirt="instance-00000001",name="new-server-test",status="ACTIVE",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
+openstack_nova_server_status{address_ipv4="1.2.3.4",address_ipv6="80fe::",availability_zone="nova",flavor_id="1",host_id="2091634baaccdc4c5a1d57069c833e402921df696b7f970791b12ec6",hypervisor_hostname="fake-mini",id="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9",instance_libvirt="instance-00000001",name="new-server-test",status="ACTIVE",task_state="",tenant_id="6f70656e737461636b20342065766572",user_id="fake",uuid="2ce4c5b3-2866-4972-93ce-77a2ea46a7f9"} 0
 # HELP openstack_nova_total_vms total_vms
 # TYPE openstack_nova_total_vms gauge
 openstack_nova_total_vms 1

--- a/integration/compute_test.go
+++ b/integration/compute_test.go
@@ -48,6 +48,7 @@ func TestComputeIntegration(t *testing.T) {
 		metrics.requireLabels(t, "openstack_nova_server_status", labels{
 			"id": server.ID, "name": server.Name, "status": "ACTIVE", "uuid": server.ID,
 		}, "flavor_id", "tenant_id", "user_id", "host_id", "hypervisor_hostname")
+		metrics.requirePresentLabels(t, "openstack_nova_server_status", labels{"id": server.ID}, "task_state")
 	})
 
 	t.Run("nova_quota_instances_admin_in_use_present", func(t *testing.T) {

--- a/integration/identity_test.go
+++ b/integration/identity_test.go
@@ -31,4 +31,8 @@ func TestIdentityIntegration(t *testing.T) {
 			failMetrics(t, metrics.body, "Expected openstack_identity_project_info metric to include parent_id label")
 		}
 	})
+
+	t.Run("identity_project_enabled_metric_present", func(t *testing.T) {
+		metrics.requireSampleWithLabels(t, "openstack_identity_project_enabled", "id")
+	})
 }


### PR DESCRIPTION
Part of #603.

Adds tenant snapshot counts, Cinder volume host labels, Nova task states, and a stable Keystone project-enabled gauge. Adds unit coverage plus integration assertions for Nova and Keystone.

Closes #203
Closes #260
Closes #314
Closes #531